### PR TITLE
fix: fetch proposals for search functionality by id instead of access the paginated array

### DIFF
--- a/ui/src/hooks/useProposal.ts
+++ b/ui/src/hooks/useProposal.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from 'react';
+import { apolloClient } from '../services/graphql';
+import { GetProposalByIdQuery } from '../queries/proposal.gql';
+import { Proposal } from './useProposals';
+
+interface ProposalData {
+  proposal: Proposal;
+}
+
+interface UseProposalResult {
+  proposal: Proposal | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useProposal(proposalId: string): UseProposalResult {
+  const [proposal, setProposal] = useState<Proposal | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProposal = useCallback(async () => {
+    if (!proposalId) return;
+    
+    setLoading(true);
+    try {
+      const result = await apolloClient.query<ProposalData>({
+        query: GetProposalByIdQuery,
+        variables: { id: proposalId },
+        fetchPolicy: 'network-only' // Always fetch from network to ensure we have the latest data
+      });
+
+      if (result.data?.proposal) {
+        setProposal(result.data.proposal);
+      } else {
+        // If the query succeeds but no proposal is found
+        setError(new Error(`Proposal with ID "${proposalId}" not found`));
+      }
+    } catch (err) {
+      console.error('Failed to fetch proposal:', err);
+      setError(err instanceof Error ? err : new Error('Failed to fetch proposal'));
+    } finally {
+      setLoading(false);
+    }
+  }, [proposalId]);
+
+  useEffect(() => {
+    fetchProposal();
+  }, [proposalId, fetchProposal]);
+
+  const refetch = () => {
+    fetchProposal();
+  };
+
+  return {
+    proposal,
+    loading,
+    error,
+    refetch
+  };
+}

--- a/ui/src/queries/proposal.gql.ts
+++ b/ui/src/queries/proposal.gql.ts
@@ -1,0 +1,18 @@
+import { gql } from "@apollo/client/core";
+
+export const GetProposalByIdQuery = gql`
+  query GetProposalById($id: String!) {
+    proposal(id: $id) {
+      id
+      title
+      body
+      author
+      space {
+        id
+        name
+        avatar
+        verified
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# fix: fetch proposals for search functionality by id instead of access the paginated array

The root cause of the bug was that the frontend was trying to find the proposal by ID from a paginated list of proposals fetched via the 
useProposals
 hook. If the specific proposal wasn't included in that batch (due to pagination limits or filtering), it would be reported as "not found" even though it exists in the GraphQL API.

The new implementation directly queries the GraphQL API for the specific proposal by ID, which ensures that any valid proposal ID will be found regardless of pagination or filtering settings.

## Types of change

- [ ] CI/CD
- [ ] New Feature
- [x] Bug Fixing
- [ ] Enhancement
- [ ] Tests

## Checklist

- [x] The code has suitable naming variables and followed all best practices (no any, nullabel ...etc)
- [x] I tested the code before pushing, and it is not crashing.
- [x] Tests should pass in local environment
- [x] Everything is documented


## Comments (optional)


## ScreenShot (optional)

