### PR TITLE
fix: bump github-workflows to v2.0.0 and add artifact-metadata:write

### DIFF
--- a/.github/workflows/ci-jfrog.yaml
+++ b/.github/workflows/ci-jfrog.yaml
@@ -13,11 +13,12 @@ concurrency:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:
   push-wei:
-    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v1.5.1
+    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v2.0.0
     with:
       repo_name: productsvents-oci-local-dev
       # group_name: productsvents
@@ -30,7 +31,7 @@ jobs:
       push: ${{ github.event_name != 'pull_request' }}
 
   push-indexer:
-    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v1.5.1
+    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v2.0.0
     with:
       repo_name: productsvents-oci-local-dev
       image_name: wei-indexer


### PR DESCRIPTION
## Summary
- Bump `NethermindEth/github-workflows` to v2.0.0
- Add `artifact-metadata: write` to workflow permissions

## Breaking change in upstream
`github-workflows` v2.0.0 now requires the `artifact-metadata: write` permission for `actions/attest-build-provenance`.

See: https://github.blog/changelog/2026-01-13-new-fine-grained-permission-for-artifact-metadata-is-now-generally-available/